### PR TITLE
Enhance commit format args, specify release

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ cli/cli trunk branch is ahead of v2.36.0 by 7 commits
 
 COMPARE: https://github.com/cli/cli/compare/v2.36.0...trunk
 
-SHA                                       DATE                  AUTHOR         MESSAGE
-49ec4842116f67fc672c01d393953cf0af22f279  2023-10-03T14:45:44Z  williammartin  Add homebrew-bump-debug workflow (#8114)
-aefecbab6515b1b864e381b6a0210cf4f90a0d0a  2023-10-03T14:54:44Z  andyfeller     Update homebrew-bump.yml...
-80e46cabebb378ae9bd70cf341517ba09b195bb1  2023-10-03T15:28:58Z  andyfeller     Update deployment.yml...
-3443a752a9949ee4f954a84f7ab94a4b99df1b27  2023-10-03T17:20:02Z  darthwalsh     docs: fix typo in pr create (#8115)...
-7a68d19c40eae8e0cb590ea91309948c9beabb97  2023-10-10T12:29:40Z  andyfeller     Merge pull request #8116 from cli/andyfe
-885ccd7424acb8db9519dc972bbac2b67c5a9d3f  2023-10-11T08:35:40Z  utouto97       Disable issue with template (#7918)...
-363dacbbed8cc9f86026ec1b1e38c6dca0d78c08  2023-10-11T13:41:00Z  kbailey4444    Set default repository for `repo clone`
+SHA       DATE                  AUTHOR            MESSAGE
+49ec4842  2023-10-03T14:45:44Z  williammartin     Add homebrew-bump-debug workflow (#8114)
+aefecbab  2023-10-03T14:54:44Z  andyfeller        Update homebrew-bump.yml...
+80e46cab  2023-10-03T15:28:58Z  andyfeller        Update deployment.yml...
+3443a752  2023-10-03T17:20:02Z  darthwalsh        docs: fix typo in pr create (#8115)...
+7a68d19c  2023-10-10T12:29:40Z  andyfeller        Merge pull request #8116 from cli/andyfeller/7718-homebrew-bump...
+885ccd74  2023-10-11T08:35:40Z  utouto97          Disable issue with template (#7918)...
+363dacbb  2023-10-11T13:41:00Z  kbailey4444       Set default repository for `repo clone` and `repo fork` (#7768)
 ```
 
 ## Quickstart
@@ -39,7 +39,10 @@ USAGE
 FLAGS
   -d, --debug                          Enable debug logging
   -h, --help                           Displays help usage
-  -H, --hostname <host>                Hostname of the GitHub instance to authenticate with
+  -H, --hostname=<host>                Hostname of the GitHub instance to authenticate with
+  -m, --message-width=<int>            Width of commit message; default '80'
+  -r, --release-tag=<string>           Release tags to calculate from; default latest
+  -s, --sha-width=<int>                Width of commit SHA; default '8'
 ```
 
 ## Setup

--- a/gh-kraken
+++ b/gh-kraken
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
+MESSAGE_WIDTH=80
+RELEASE_TAG=
+SHA_WIDTH=8
+
 __USAGE="
 Identify unreleased changes compared to latest release.
 
@@ -12,7 +16,10 @@ USAGE
 FLAGS
   -d, --debug                          Enable debug logging
   -h, --help                           Displays help usage
-  -H, --hostname <host>                Hostname of the GitHub instance to authenticate with
+  -H, --hostname=<host>                Hostname of the GitHub instance to authenticate with
+  -m, --message-width=<int>            Width of commit message; default '$MESSAGE_WIDTH'
+  -r, --release-tag=<string>           Release tags to calculate from; default latest
+  -s, --sha-width=<int>                Width of commit SHA; default '$SHA_WIDTH'
 ";
 
 die() {
@@ -25,7 +32,7 @@ if ! type -p gh > /dev/null; then
 	die "'gh' could not be found"
 fi
 
-while getopts "dhH:-:" OPT; do
+while getopts "dhH:m:r:s:-:" OPT; do
 	if [ "$OPT" = "-" ]; then     # long option: reformulate OPT and OPTARG
 		OPT="${OPTARG%%=*}"       # extract long option name
 		OPTARG="${OPTARG#"$OPT"}" # extract long option argument (may be empty)
@@ -46,6 +53,18 @@ while getopts "dhH:-:" OPT; do
 
         hostname | H)
             export GH_HOST="${OPTARG}"
+            ;;
+
+        message-width | m)
+            export MESSAGE_WIDTH="${OPTARG}"
+            ;;
+
+        release-tag | r)
+            export RELEASE_TAG="${OPTARG}"
+            ;;
+
+        sha-width | s)
+            export SHA_WIDTH="${OPTARG}"
             ;;
 
 		*)
@@ -76,18 +95,33 @@ else
 fi
 
 DEFAULT_BRANCH=$(gh api "/repos/$OWNER/$REPO" --jq '.default_branch')
-LATEST_RELEASE_TAG=$(gh api "/repos/$OWNER/$REPO/releases/latest" --jq '.tag_name')
 
+if [ -z "$RELEASE_TAG" ]; then
+	RELEASE_TAG=$(gh api "/repos/$OWNER/$REPO/releases/latest" --jq '.tag_name')
+fi
+
+#
+# When thinking about formatting and available real estate
+#
+#          1         2         3         4         5         6         7         8
+# 12345678901234567890123456789012345678901234567890123456789012345678901234567890
+#
+# ab7e55e2  2023-12-12T23:36:40Z  samueldurantes  Add more help message to browse command
+# ab7e55e20a4594bfbec6a3bdd204926ee95d145c
+#
+# By shortening the SHA artifically from 40 characters to 8, we can extend the commit message a little.
+# Unfortunately, usernames can max at 39 characters, so this isn't perfectly vt100 80 character limited.
+#
 export TEMPLATE="
-$OWNER/$REPO $DEFAULT_BRANCH branch is {{ .status }} of $LATEST_RELEASE_TAG by {{ .total_commits }} commits
+$OWNER/$REPO $DEFAULT_BRANCH branch is {{ .status }} of $RELEASE_TAG by {{ .total_commits }} commits
 
 COMPARE: {{ .html_url }}
 
 {{  tablerow \"SHA\" \"DATE\" \"AUTHOR\" \"MESSAGE\"  }}
 {{- range .commits }}
-{{- tablerow .sha .commit.author.date .author.login (printf \"%.40s\" .commit.message) }}
+{{- tablerow (printf \"%.*s\" $SHA_WIDTH .sha) .commit.author.date .author.login (printf \"%.*s\" $MESSAGE_WIDTH .commit.message) }}
 {{- end }}
 {{- tablerender }}
 "
 
-gh api "/repos/$OWNER/$REPO/compare/$LATEST_RELEASE_TAG...$DEFAULT_BRANCH" --template "$TEMPLATE"
+gh api "/repos/$OWNER/$REPO/compare/$RELEASE_TAG...$DEFAULT_BRANCH" --template "$TEMPLATE"

--- a/gh-kraken
+++ b/gh-kraken
@@ -43,7 +43,7 @@ while getopts "dhH:m:r:s:-:" OPT; do
 
 		debug | d)
 			set -x
-			DEBUG=true
+			GH_DEBUG=api
 			;;
 
 		help | h)


### PR DESCRIPTION
This commit expands several aspects of the extension

1. The ability to control the precision of the commit SHA, moving from 40 to 8 characters by default
2. The ability to control the precision of the commit message, moving from 40 to 80 characters by default
3. The ability to specify the release tag to calculate changes from, defaulting to latest if none provided

In addition, the README has been updated to reflect the new output and updated usage info.
